### PR TITLE
(#31) check client_activated property when loading DDLs

### DIFF
--- a/lib/mcollective/application/plugin.rb
+++ b/lib/mcollective/application/plugin.rb
@@ -213,7 +213,7 @@ mco plugin package [options] <directory>
     def load_plugin_ddl(plugin, type)
       [plugin, "#{plugin}_#{type}"].each do |p|
         ddl = DDL.new(p, type, false)
-        if ddl.findddlfile(p, type)
+        if ddl.client_activated? && ddl.findddlfile(p, type)
           ddl.loadddlfile
           return ddl
         end
@@ -224,9 +224,14 @@ mco plugin package [options] <directory>
 
     # Show application list and plugin help
     def doc_command
-      known_plugin_types = [["Agents", :agent], ["Aggregate", :aggregate],
-                            ["Connectors", :connector], ["Data Queries", :data],
-                            ["Discovery Methods", :discovery], ["Validator Plugins", :validator]]
+      known_plugin_types = [
+        ["Agents", :agent],
+        ["Aggregate", :aggregate],
+        ["Connectors", :connector],
+        ["Data Queries", :data],
+        ["Discovery Methods", :discovery],
+        ["Validator Plugins", :validator]
+      ]
 
       if configuration.include?(:target) && configuration[:target] != "."
         if configuration[:target] =~ /^(.+?)\/(.+)$/
@@ -265,7 +270,11 @@ mco plugin package [options] <directory>
 
           PluginManager.find(plugin_type[1], "ddl").each do |ddl|
             begin
-              help = DDL.new(ddl, plugin_type[1])
+              help = DDL.new(ddl, plugin_type[1], false)
+
+              next unless help.client_activated?
+
+              help.loadddlfile
               pluginname = ddl.gsub(/_#{plugin_type[1]}$/, "")
               puts "  %-25s %s" % [pluginname, help.meta[:description]]
             rescue => e

--- a/lib/mcollective/ddl/agentddl.rb
+++ b/lib/mcollective/ddl/agentddl.rb
@@ -44,6 +44,10 @@ module MCollective
         super
       end
 
+      def client_activated?
+        Util.str_to_bool(@config.pluginconf.fetch("%s.activate_client" % @pluginname, ACTIVATION_DEFAULT.to_s))
+      end
+
       def input(argument, properties)
         raise "Input needs a :optional property" unless properties.include?(:optional)
 

--- a/lib/mcollective/ddl/base.rb
+++ b/lib/mcollective/ddl/base.rb
@@ -19,6 +19,8 @@ module MCollective
     class Base
       attr_reader :meta, :entities, :pluginname, :plugintype, :usage, :requirements
 
+      ACTIVATION_DEFAULT = true
+
       def initialize(plugin, plugintype=:agent, loadddl=true)
         @entities = {}
         @meta = {}
@@ -77,6 +79,10 @@ module MCollective
       end
 
       def loadddlfile
+        if @config.mode == :client && !client_activated?
+          raise("%s/%s is disabled, cannot load DDL file" % [@plugintype, @pluginname])
+        end
+
         if ddlfile = findddlfile
           instance_eval(File.read(ddlfile), ddlfile, 1)
         else
@@ -95,7 +101,12 @@ module MCollective
             return ddlfile
           end
         end
-        return false
+
+        false
+      end
+
+      def client_activated?
+        ACTIVATION_DEFAULT
       end
 
       def validate_requirements


### PR DESCRIPTION
In future we'll ship all DDLs for core plugins in this gem and need
a different way to remove agents from the client list of known agents
so we added a client_activated setting which can now prevent a DDL from
being loaded.

Today this defaults to activated true, we'll switch to false when ready