### PR TITLE
(#58) :array inputs are treated like :list

### DIFF
--- a/lib/mcollective/ddl/base.rb
+++ b/lib/mcollective/ddl/base.rb
@@ -149,7 +149,7 @@ module MCollective
 
         return true
       rescue => e
-        raise DDLValidationError, "Cannot validate input %s: %s" % [key, e.to_s]
+        raise DDLValidationError, "Cannot validate input %s: %s" % [key, e.to_s], e.backtrace
       end
 
       # Registers an input argument for a given action

--- a/lib/mcollective/validator.rb
+++ b/lib/mcollective/validator.rb
@@ -57,7 +57,7 @@ module MCollective
       Validator.load_validators
 
       begin
-        if [:integer, :boolean, :float, :number, :string].include?(validation)
+        if [:integer, :boolean, :float, :number, :string, :array].include?(validation)
           Validator.typecheck(validator, validation)
 
         else
@@ -76,7 +76,7 @@ module MCollective
           end
         end
       rescue => e
-        raise ValidatorError, e.to_s
+        raise ValidatorError, e.to_s, e.backtrace
       end
     end
   end

--- a/lib/mcollective/validator/typecheck_validator.rb
+++ b/lib/mcollective/validator/typecheck_validator.rb
@@ -19,6 +19,8 @@ module MCollective
           validator.is_a?(String)
         when :boolean
           [TrueClass, FalseClass].include?(validator.class)
+        when :array
+          validator.is_a?(Array)
         else
           false
         end

--- a/spec/unit/mcollective/ddl/base_spec.rb
+++ b/spec/unit/mcollective/ddl/base_spec.rb
@@ -177,6 +177,18 @@ module MCollective
           @ddl.validate_input_argument(@ddl.entities[:test][:input], :number, 1)
           @ddl.validate_input_argument(@ddl.entities[:test][:input], :number, 1.1)
         end
+
+        it "should validate array arguments correctly" do
+          @ddl.action(:test, :description => "rspec")
+          @ddl.instance_variable_set("@current_entity", :test)
+          @ddl.input(:array, :prompt => "prompt", :description => "descr",
+                      :type => :array, :default => [], :optional => true)
+          expect {
+            @ddl.validate_input_argument(@ddl.entities[:test][:input], :array, "1")
+          }.to raise_error("Cannot validate input array: value should be a array")
+          @ddl.validate_input_argument(@ddl.entities[:test][:input], :array, [1])
+          @ddl.validate_input_argument(@ddl.entities[:test][:input], :array, [])
+        end
       end
 
       describe "#requires" do


### PR DESCRIPTION
DDLs support type of :array which should just ensure the input is
an array instead its reating them like :list which tries to validate
the given value is within the values supplied as :list, however :array
would not have :list set.

This adds special :array handling and tests