### PR TITLE
(#60) Fix :hash input validation

### DIFF
--- a/lib/mcollective/validator.rb
+++ b/lib/mcollective/validator.rb
@@ -57,7 +57,7 @@ module MCollective
       Validator.load_validators
 
       begin
-        if [:integer, :boolean, :float, :number, :string, :array].include?(validation)
+        if [:integer, :boolean, :float, :number, :string, :array, :hash].include?(validation)
           Validator.typecheck(validator, validation)
 
         else

--- a/lib/mcollective/validator/typecheck_validator.rb
+++ b/lib/mcollective/validator/typecheck_validator.rb
@@ -21,6 +21,8 @@ module MCollective
           [TrueClass, FalseClass].include?(validator.class)
         when :array
           validator.is_a?(Array)
+        when :hash
+          validator.is_a?(Hash)
         else
           false
         end

--- a/spec/unit/mcollective/ddl/base_spec.rb
+++ b/spec/unit/mcollective/ddl/base_spec.rb
@@ -189,6 +189,18 @@ module MCollective
           @ddl.validate_input_argument(@ddl.entities[:test][:input], :array, [1])
           @ddl.validate_input_argument(@ddl.entities[:test][:input], :array, [])
         end
+
+        it "should validate hash arguments correctly" do
+          @ddl.action(:test, :description => "rspec")
+          @ddl.instance_variable_set("@current_entity", :test)
+          @ddl.input(:hash, :prompt => "prompt", :description => "descr",
+                      :type => :hash, :default => {}, :optional => true)
+          expect {
+            @ddl.validate_input_argument(@ddl.entities[:test][:input], :hash, "1")
+          }.to raise_error("Cannot validate input hash: value should be a hash")
+          @ddl.validate_input_argument(@ddl.entities[:test][:input], :hash, {:a => 1})
+          @ddl.validate_input_argument(@ddl.entities[:test][:input], :hash, {})
+        end
       end
 
       describe "#requires" do


### PR DESCRIPTION
DDL support type of :hash which was not handled before. This commit adds
special :hash handling and tests.

This closes #60 