### PR TITLE
(#65) Fix facts application when querying non-string facts

### DIFF
--- a/lib/mcollective/application/facts.rb
+++ b/lib/mcollective/application/facts.rb
@@ -12,6 +12,8 @@ class MCollective::Application::Facts<MCollective::Application
   def show_single_fact_report(fact, facts, verbose=false)
     puts("Report for fact: #{fact}\n\n")
 
+    facts = stringify_facts_hash(facts)
+
     field_size = MCollective::Util.field_size(facts.keys)
     facts.keys.sort.each do |k|
       printf("        %-#{field_size}s found %d times\n", k, facts[k].size)
@@ -26,6 +28,12 @@ class MCollective::Application::Facts<MCollective::Application
         puts
       end
     end
+  end
+
+  def stringify_facts_hash(facts)
+    res = Hash.new([])
+    facts.each { |k, v| res[k.to_s] += v }
+    res
   end
 
   def main

--- a/spec/unit/mcollective/application/facts_spec.rb
+++ b/spec/unit/mcollective/application/facts_spec.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+require 'mcollective/application/facts'
+
+module MCollective
+  class Application
+    describe Facts do
+      describe "#stringify_facts_hash" do
+        it "should convert keys to strings" do
+          h = { 2 => ["node1"], true: ["node2", "node3"] }
+
+          expect(subject.stringify_facts_hash(h)).to eq({
+            "2" => ["node1"],
+            "true" => ["node2", "node3"],
+          })
+        end
+
+        it "should merge equivalent keys" do
+          h = { true => ["node1"], "true": ["node2", "node3"] }
+
+          expect(subject.stringify_facts_hash(h)).to eq({
+            "true" => ["node1", "node2", "node3"],
+          })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Not sure if here if fixing this kind of problems still makes sense or if another location is more suitable…  Anyway, this should improve some `mco facts` usage I rely on.