### PR TITLE
Allow to run tasks as another user

### DIFF
--- a/lib/mcollective/agent/bolt_tasks.ddl
+++ b/lib/mcollective/agent/bolt_tasks.ddl
@@ -77,6 +77,15 @@ action "run_and_wait", :description => "Runs a Puppet Task that was previously d
         :default     => "{}",
         :maxlength   => 102400
 
+  input :run_as,
+        :prompt      => "Run As",
+        :description => "User to run the task as",
+        :type        => :string,
+        :validation  => ".+",
+        :optional    => true,
+        :default     => nil,
+        :maxlength   => 32
+
   output :task_id,
          :description => "The ID the task was created with",
          :display_as  => "Task ID",
@@ -164,6 +173,15 @@ action "run_no_wait", :description => "Runs a Puppet Task that was previously do
         :optional    => true,
         :default     => "{}",
         :maxlength   => 102400
+
+  input :run_as,
+        :prompt      => "Run As",
+        :description => "User to run the task as",
+        :type        => :string,
+        :validation  => ".+",
+        :optional    => true,
+        :default     => nil,
+        :maxlength   => 32
 
   output :task_id,
          :description => "The ID the task was created with",

--- a/lib/mcollective/agent/bolt_tasks.json
+++ b/lib/mcollective/agent/bolt_tasks.json
@@ -101,6 +101,15 @@
           "optional": false,
           "validation": "^.+$",
           "maxlength": 102400
+        },
+        "run_as": {
+          "prompt": "Run As",
+          "description": "User to run the task as",
+          "type": "string",
+          "default": null,
+          "optional": true,
+          "validation": ".+",
+          "maxlength": 32
         }
       },
       "output": {
@@ -233,6 +242,15 @@
           "optional": true,
           "validation": "^.+$",
           "maxlength": 102400
+        },
+        "run_as": {
+          "prompt": "Run As",
+          "description": "User to run the task as",
+          "type": "string",
+          "default": null,
+          "optional": true,
+          "validation": ".+",
+          "maxlength": 32
         }
       },
       "output": {

--- a/lib/mcollective/agent/bolt_tasks.rb
+++ b/lib/mcollective/agent/bolt_tasks.rb
@@ -37,7 +37,8 @@ module MCollective
           "task" => request[:task],
           "input_method" => request[:input_method],
           "input" => request[:input],
-          "files" => JSON.parse(request[:files])
+          "files" => JSON.parse(request[:files]),
+          "run_as" => request[:run_as]
         }
 
         unless tasks.cached?(task["files"])
@@ -77,7 +78,8 @@ module MCollective
           "task" => request[:task],
           "input_method" => request[:input_method],
           "input" => request[:input],
-          "files" => JSON.parse(request[:files])
+          "files" => JSON.parse(request[:files]),
+          "run_as" => request[:run_as]
         }
 
         status = tasks.run_task_command(reply[:task_id], task, false, request.caller)

--- a/lib/mcollective/application/tasks.rb
+++ b/lib/mcollective/application/tasks.rb
@@ -148,6 +148,13 @@ Examples:
                           :required => false,
                           :default => 1,
                           :type => Integer
+
+        self.class.option :__run_as,
+                          :arguments => ["--run-as USERNAME"],
+                          :description => "Run task as user USERNAME",
+                          :required => false,
+                          :default => nil,
+                          :type => String
       end
 
       def say(msg="")
@@ -179,6 +186,8 @@ Examples:
           :task => task,
           :files => meta["files"].to_json
         }
+
+        request[:run_as] = configuration[:__run_as] if configuration[:__run_as]
 
         request[:input] = input.to_json if input
 

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -270,7 +270,8 @@ terminate called after throwing an instance of 'leatherman::json_container::data
               "_choria_task_caller" => "choria=local.mcollective"
             },
             instance_of(String),
-            File.join(cache, "test_1")
+            File.join(cache, "test_1"),
+            nil
           )
 
           ts.stubs(:cached?).returns(true)
@@ -323,7 +324,7 @@ terminate called after throwing an instance of 'leatherman::json_container::data
         it "should run the command and write all the right files" do
           FileUtils.mkdir_p(spool = File.join(cache, "spawn_test_1"))
 
-          pid = ts.spawn_command("/bin/cat", {}, "hello world", spool)
+          pid = ts.spawn_command("/bin/cat", {}, "hello world", spool, nil)
 
           Timeout.timeout(1) do
             sleep 0.1 until File::Stat.new(File.join(spool, "wrapper_stdout")).size > 0 # rubocop:disable Style/ZeroLengthPredicate
@@ -338,7 +339,7 @@ terminate called after throwing an instance of 'leatherman::json_container::data
         it "should set environment" do
           FileUtils.mkdir_p(spool = File.join(cache, "spawn_test_2"))
 
-          pid = ts.spawn_command("/usr/bin/env", {"RSPEC_TEST" => "hello world"}, nil, spool)
+          pid = ts.spawn_command("/usr/bin/env", {"RSPEC_TEST" => "hello world"}, nil, spool, nil)
 
           Timeout.timeout(1) do
             sleep 0.1 until File::Stat.new(File.join(spool, "wrapper_stdout")).size > 0 # rubocop:disable Style/ZeroLengthPredicate


### PR DESCRIPTION
This is part of https://github.com/choria-io/mcollective-choria/issues/439

Environment is currently not reset (e.g. `$HOME`, `$USER`, `$LOGNAME` are still showing calling processes values).  When running a task that shows output of `id(1)` and `env(1)` with `mco tasks run testmodule::testtask --run-as romain -I $(hostname -f)` I get this:

```
===> id
uid=1000(romain) gid=1000(romain) groupes=1000(romain)
===> env
LC_TIME=fr_FR.UTF-8
USER=root
HOME=/root
LC_MONETARY=fr_FR.UTF-8
LOGNAME=root
JOURNAL_STREAM=9:247574
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
INVOCATION_ID=dc6dbb00fb054c5bbc973e59a24a3fb4
PT__installdir=/opt/puppetlabs/mcollective/tasks-spool/878eb6153e5a50f1927647309ce5df6f/files
LC_ADDRESS=fr_FR.UTF-8
_task=testmodule::testtask
LANG=fr_FR.UTF-8
LC_TELEPHONE=fr_FR.UTF-8
_choria_task_caller=choria=romain.mcollective
LC_NAME=fr_FR.UTF-8
SHELL=/bin/sh
LC_MEASUREMENT=fr_FR.UTF-8
LC_IDENTIFICATION=fr_FR.UTF-8
_choria_task_id=878eb6153e5a50f1927647309ce5df6f
PWD=/
LC_NUMERIC=fr_FR.UTF-8
LC_PAPER=fr_FR.UTF-8
```
