### PR TITLE
(nisc) Fix deprecation warning `Object#=~ is called on Integer`

### DIFF
--- a/lib/mcollective/rpc/client.rb
+++ b/lib/mcollective/rpc/client.rb
@@ -822,7 +822,7 @@ module MCollective
             @stdout.print twirl.twirl(respcount, discovered.size)
           end
 
-          if batch_size =~ /^(\d+)%$/
+          if batch_size.is_a?(String) && batch_size =~ /^(\d+)%$/
             # determine batch_size as a percentage of the discovered array's size
             batch_size = (discovered.size / 100.0 * Integer($1)).ceil
           else


### PR DESCRIPTION
Make sure variable is a String before matching it against a regular expression.

Fixes:
```
lib/mcollective/rpc/client.rb:825: warning: deprecated Object#=~ is called on Integer; it always returns nil
```