### PR TITLE
(misc) Cleanup environment when changing user

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -283,6 +283,7 @@ module MCollective
           if pid.nil?
             Process.gid = Process.egid = u.gid
             Process.uid = Process.euid = u.uid
+            ENV.delete_if { |name| name !~ /^LC_/ }
             Process.exec(environment, command, options)
           end
         else


### PR DESCRIPTION
When running a process after changing the process uid/gid, the
environment can contain sensitive information from the caller user
environment, and features misleading information in some environment
variables such as `HOME`, `USER` or `MAIL`.

Drop all environment variables except from LC_* before exec to avoid
this.

Maybe in the future we will need or want to add a feature to white-list
some environment variables to keep, or set environment variables to a
given value.