### PR TITLE
(misc) Pass validation for unset optional values

### DIFF
--- a/lib/mcollective/data.rb
+++ b/lib/mcollective/data.rb
@@ -54,8 +54,6 @@ module MCollective
       raise DDLValidationError, "No output has been defined in the DDL for data plugin #{name}" if output.keys.empty?
 
       if input[:query]
-        return true if argument.nil? && input[:query][:optional]
-
         ddl.validate_input_argument(input, :query, argument)
       else
         raise("No data plugin argument was declared in the %s DDL but an input was supplied" % name) if argument

--- a/lib/mcollective/ddl/base.rb
+++ b/lib/mcollective/ddl/base.rb
@@ -123,13 +123,14 @@ module MCollective
       # all the use cases are clear
       #
       # only does validation for arguments actually given, since some might
-      # be optional.  We validate the presense of the argument earlier so
-      # this is a safe assumption, just to skip them.
+      # be optional.
       #
       # :string can have maxlength and regex.  A maxlength of 0 will bypasss checks
       # :list has a array of valid values
       def validate_input_argument(input, key, argument)
         Validator.load_validators
+
+        return true if argument.nil? && input[key][:optional]
 
         case input[key][:type]
         when :string

--- a/spec/unit/mcollective/data_spec.rb
+++ b/spec/unit/mcollective/data_spec.rb
@@ -150,12 +150,6 @@ module MCollective
         expect { Data.ddl_validate(@ddl, "rspec") }.to raise_error("No output has been defined in the DDL for data plugin rspec test")
       end
 
-      it "should skip optional arguments that were not supplied" do
-        @ddl.expects(:entities).returns({:data => {:input => {:query => {:optional => true}}, :output => {:test => {}}}})
-        @ddl.expects(:validate_input_argument).never
-        expect(Data.ddl_validate(@ddl, nil)).to eq(true)
-      end
-
       it "should validate the argument" do
         @ddl.expects(:entities).returns({:data => {:input => {:query => {}}, :output => {:test => {}}}})
         @ddl.expects(:validate_input_argument).returns("rspec validated")

--- a/spec/unit/mcollective/ddl/base_spec.rb
+++ b/spec/unit/mcollective/ddl/base_spec.rb
@@ -61,6 +61,28 @@ module MCollective
           Config.instance.stubs(:libdir).returns([File.join(File.dirname(__FILE__), "../../../plugins")])
         end
 
+        it "should ensure optional parameters are accepted when nil" do
+          @ddl.action(:string, :description => "rspec")
+          @ddl.instance_variable_set("@current_entity", :string)
+          @ddl.input(:string, :prompt => "prompt", :description => "descr",
+                     :type => :string, :optional => true, :validation => "",
+                     :maxlength => 1)
+
+          @ddl.validate_input_argument(@ddl.entities[:string][:input], :string, nil)
+        end
+
+        it "should ensure non-optional parameters are rejected when nil" do
+          @ddl.action(:string, :description => "rspec")
+          @ddl.instance_variable_set("@current_entity", :string)
+          @ddl.input(:string, :prompt => "prompt", :description => "descr",
+                     :type => :string, :optional => false, :validation => "",
+                     :maxlength => 1)
+
+          expect {
+            @ddl.validate_input_argument(@ddl.entities[:string][:input], :string, nil)
+          }.to raise_error("Cannot validate input string: value should be a string")
+        end
+
         it "should ensure strings are String" do
           @ddl.action(:string, :description => "rspec")
           @ddl.instance_variable_set("@current_entity", :string)


### PR DESCRIPTION
When a parameter is optional and unset, we do not want to validate that
value against the type and validation for the parameter.

A comment indicates that this check is already performed earlier, but it
seems to not be the case in all cases (maybe due to refactoring).

Remove the misleading comment and skip validation if parameter is not
set and is optional, a similar way it is done in
MCollective::Data.ddl_validate()

This helps fixing https://github.com/choria-io/puppet-choria/pull/222

The second commit remove the now redundant check.