### PR TITLE
(misc) Make it easier to work with bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,24 +1,7 @@
 require "rubygems"
 require "rubygems/package_task"
 
-PROJ_VERSION = "2.23.3"
-
-spec = Gem::Specification.new do |s|
-  s.name = "choria-mcorpc-support"
-  s.version = PROJ_VERSION
-  s.license = "Apache-2.0"
-  s.author = "R.I.Pienaar"
-  s.email = "rip@devco.net"
-  s.homepage = "https://choria.io/"
-  s.summary = "Support libraries the Choria Server"
-  s.description = "Libraries enabling Ruby support for the Choria Orchestration Server"
-  s.files = FileList["{lib,bin}/**/*"].to_a
-  s.require_path = "lib"
-  s.bindir = "bin"
-  s.executables = ["mco"]
-  s.add_dependency "systemu", "~> 2.6", ">= 2.6.4"
-  s.add_dependency "nats-pure", "~> 0.6"
-end
+spec = Gem::Specification.load('mcorpc-ruby-support.gemspec')
 
 Gem::PackageTask.new(spec) do |pkg|
   pkg.need_tar = false

--- a/mcorpc-ruby-support.gemspec
+++ b/mcorpc-ruby-support.gemspec
@@ -1,0 +1,20 @@
+require "rake"
+
+PROJ_VERSION = "2.23.3"
+
+Gem::Specification.new do |s|
+  s.name = "choria-mcorpc-support"
+  s.version = PROJ_VERSION
+  s.license = "Apache-2.0"
+  s.author = "R.I.Pienaar"
+  s.email = "rip@devco.net"
+  s.homepage = "https://choria.io/"
+  s.summary = "Support libraries the Choria Server"
+  s.description = "Libraries enabling Ruby support for the Choria Orchestration Server"
+  s.files = FileList["{lib,bin}/**/*"].to_a
+  s.require_path = "lib"
+  s.bindir = "bin"
+  s.executables = ["mco"]
+  s.add_dependency "systemu", "~> 2.6", ">= 2.6.4"
+  s.add_dependency "nats-pure", "~> 0.6"
+end


### PR DESCRIPTION
While hacking in this gem a user might want to run another project with
their work-in-progress code.  This can be achieved by using something like
the following in that other project's Gemfile:

```ruby
gem 'choria-mcorpc-support', path: '../choria-io/mcorpc-ruby-support'
```

Unfortunately, with the gem specification bundled into the Rakefile,
bundler cannot access it and this result in a failure:

```sh-session
romain@zappy ~/Projects/inventory % bundle
Fetching gem metadata from https://rubygems.org/..
Could not find gem 'choria-mcorpc-support' in source at `../choria-io/mcorpc-ruby-support`.
The source does not contain any versions of 'choria-mcorpc-support'
```

Move the specification in a dedicated Ruby file, and load it from the
Rakefile to prevent this from happening and making it easier to work on
a work-in-porogress gem.