### PR TITLE
(#142) relocate task scripts in spooldir

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -157,7 +157,7 @@ module MCollective
       # @return [String] path to the command
       def task_command(spooldir, task)
         file_spec = task["files"][0]
-        file_name = File.join(spooldir, "files", file_spec["filename"])
+        file_name = File.join(spooldir, "files", task_module(task["task"]), "tasks", file_spec["filename"])
 
         command = platform_specific_command(file_name)
 
@@ -220,7 +220,10 @@ module MCollective
       # @param task [Hash] task specification
       def populate_spooldir(spooldir, task)
         task["files"].each do |file|
-          spool_filename = File.join(spooldir, "files", file["filename"])
+          filename = file["filename"]
+          filename = File.join(task_module(task["task"]), "tasks", filename) unless filename.index("/")
+
+          spool_filename = File.join(spooldir, "files", filename)
 
           FileUtils.mkdir_p(File.dirname(spool_filename), :mode => 0o0750)
           FileUtils.cp(task_file_name(file), spool_filename)
@@ -567,6 +570,15 @@ module MCollective
         parts << "init" if parts.size == 1
 
         parts
+      end
+
+      # Return a task's module
+      #
+      # @param task [String]
+      # @return [String] the module name
+      # @raise [StandardError] for invalid task names
+      def task_module(task)
+        parse_task(task)[0]
       end
 
       # Determines the cache path for a task file

--- a/spec/fixtures/tasks/choria_ls_metadata.json
+++ b/spec/fixtures/tasks/choria_ls_metadata.json
@@ -1,6 +1,5 @@
 {
   "metadata": {
-    "puppet_task_version": 1,
     "description": "Get directory contents",
     "input_method": "stdin",
     "parameters": {
@@ -10,6 +9,7 @@
       }
     }
   },
+  "name": "choria::ls",
   "files": [
     {
       "filename": "ls.rb",

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -379,8 +379,8 @@ terminate called after throwing an instance of 'leatherman::json_container::data
           "/tmp/tasks-spool-#{$$}"
         end
         it "should copy files" do
-          FileUtils.expects(:mkdir_p).with(File.join(spooldir, "files"), :mode => 0o750)
-          FileUtils.expects(:cp).with(File.join(cache, "f3b4821836cf7fe6fe17dfb2924ff6897eba43a44cc4cba0e0ed136b27934ede"), File.join(spooldir, "files", "ls.rb"))
+          FileUtils.expects(:mkdir_p).with(File.join(spooldir, "files", "choria", "tasks"), :mode => 0o750)
+          FileUtils.expects(:cp).with(File.join(cache, "f3b4821836cf7fe6fe17dfb2924ff6897eba43a44cc4cba0e0ed136b27934ede"), File.join(spooldir, "files", "choria", "tasks", "ls.rb"))
           ts.populate_spooldir(spooldir, task_fixture)
         end
       end
@@ -422,13 +422,13 @@ terminate called after throwing an instance of 'leatherman::json_container::data
           expect(ts.task_command(cache, task_run_request_fixture)).to eq(
             [
               "/opt/puppetlabs/puppet/bin/PowershellShim.ps1",
-              "#{cache}/files/test.ps1"
+              "#{cache}/files/choria/tasks/test.ps1"
             ]
           )
         end
 
         it "should use the platform specific command otherwise" do
-          expect(ts.task_command(cache, task_run_request_fixture)).to eq(["#{cache}/files/ls.rb"])
+          expect(ts.task_command(cache, task_run_request_fixture)).to eq(["#{cache}/files/choria/tasks/ls.rb"])
         end
       end
 

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -381,7 +381,7 @@ terminate called after throwing an instance of 'leatherman::json_container::data
         it "should copy files" do
           FileUtils.expects(:mkdir_p).with(File.join(spooldir, "files", "choria", "tasks"), :mode => 0o750)
           FileUtils.expects(:cp).with(File.join(cache, "f3b4821836cf7fe6fe17dfb2924ff6897eba43a44cc4cba0e0ed136b27934ede"), File.join(spooldir, "files", "choria", "tasks", "ls.rb"))
-          ts.populate_spooldir(spooldir, task_fixture)
+          ts.populate_spooldir(spooldir, task_run_request_fixture)
         end
       end
 

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -630,13 +630,13 @@ terminate called after throwing an instance of 'leatherman::json_container::data
 
       describe "#file_size" do
         it "should calculate the correct size" do
-          expect(ts.file_size("spec/fixtures/tasks/choria_ls_metadata.json")).to eq(569)
+          expect(ts.file_size("spec/fixtures/tasks/choria_ls_metadata.json")).to eq(563)
         end
       end
 
       describe "#file_sha256" do
         it "should calculate the right sha256" do
-          expect(ts.file_sha256("spec/fixtures/tasks/choria_ls_metadata.json")).to eq("9c98b23902538c0c1483eee76f14c9b96320289a82b9f848cdc3d17e4802e195")
+          expect(ts.file_sha256("spec/fixtures/tasks/choria_ls_metadata.json")).to eq("37d20c3daf13d6347c1bc566e36a54e608abce7394fbbcb23f1785573675ea1f")
         end
       end
 


### PR DESCRIPTION
When setting up the spooldir, ensure the actual task entry point is copied as `<module name>/tasks/<task-name>`.  This way, tasks referring to other resources using relative path will be able to find them.

Fixes #142