### PR TITLE
(#149) Align MCollective::Util::Choria options processing with choria

### DIFF
--- a/lib/mcollective/config.rb
+++ b/lib/mcollective/config.rb
@@ -137,6 +137,8 @@ module MCollective
 
         raise('Identities can only match /\w\.\-/') unless @identity =~ /^[\w.\-]+$/
 
+        check_deprecations
+
         @configured = true
 
         libdirs.each do |dir|
@@ -252,6 +254,14 @@ module MCollective
           val = $2
           @pluginconf["#{plugin}.#{key}"] = val
         end
+      end
+    end
+
+    def check_deprecations
+      if @pluginconf["choria.use_srv_records"]
+        Log.warn("Configuration set 'choria.use_srv_records' which is deprecated in favor of 'choria.use_srv'.")
+        @pluginconf["choria.use_srv"] = @pluginconf["choria.use_srv_records"]
+        @pluginconf.delete("choria.use_srv_records")
       end
     end
   end

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -157,19 +157,19 @@ module MCollective
 
       # Determines if SRV records should be used
       #
-      # Setting choria.use_srv_records to anything other than t, true, yes or 1 will disable
+      # Setting choria.use_srv to anything other than t, true, yes or 1 will disable
       # SRV records
       #
       # @return [Boolean]
       def should_use_srv?
-        ["t", "true", "yes", "1"].include?(get_option("choria.use_srv_records", "1").downcase)
+        ["t", "true", "yes", "1"].include?(get_option("choria.use_srv", "1").downcase)
       end
 
       # Query DNS for a series of records
       #
       # The given records will be passed through {#srv_records} to figure out the domain to query in.
       #
-      # Querying of records can be bypassed by setting choria.use_srv_records to false
+      # Querying of records can be bypassed by setting choria.use_srv to false
       #
       # @yield [Hash] each record for modification by the caller
       # @param records [Array<String>] the records to query without their domain parts
@@ -634,21 +634,27 @@ module MCollective
 
       # The PuppetDB server to connect to
       #
-      # Will consult _x-puppet-db._tcp.example.net then _x-puppet._tcp.example.net
-      # then configurable using choria.puppetdb_host and choria.puppetdb_port, defaults
-      # to puppet:8081
+      # Use choria.puppetdb_host if set, otherwise query
+      # _x-puppet-db._tcp.example.net then _x-puppet._tcp.example.net if SRV
+      # lookup is enabled, and fallback to puppet:8081 if nothing else worked.
       #
       # @return [Hash] with :target and :port
       def puppetdb_server
-        d_host = get_option("choria.puppetdb_host", "puppet")
         d_port = get_option("choria.puppetdb_port", "8081")
+
+        answer = {
+          :target => get_option("choria.puppetdb_host", nil),
+          :port => d_port
+        }
+
+        return answer if answer[:target]
 
         answer = try_srv(["_x-puppet-db._tcp"], nil, nil)
         return answer if answer[:target]
 
         # In the case where we take _x-puppet._tcp SRV records we unfortunately have
         # to force the port else it uses the one from Puppet which will 404
-        answer = try_srv(["_x-puppet._tcp"], d_host, d_port)
+        answer = try_srv(["_x-puppet._tcp"], "puppet", d_port)
         answer[:port] = d_port
 
         answer

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -322,13 +322,13 @@ module MCollective
 
         it "should support common 'on' settings" do
           ["t", "true", "yes", "1"].each do |setting|
-            Config.instance.stubs(:pluginconf).returns("choria.use_srv_records" => setting)
+            Config.instance.stubs(:pluginconf).returns("choria.use_srv" => setting)
             expect(choria.should_use_srv?).to be(true)
           end
         end
 
         it "should support disabling SRV" do
-          Config.instance.stubs(:pluginconf).returns("choria.use_srv_records" => "false")
+          Config.instance.stubs(:pluginconf).returns("choria.use_srv" => "false")
           expect(choria.should_use_srv?).to be(false)
         end
       end
@@ -402,7 +402,7 @@ module MCollective
         end
 
         it "should support defaults" do
-          Config.instance.stubs(:pluginconf).returns("choria.puppetdb_host" => "puppet", "choria.puppetdb_port" => "8081")
+          Config.instance.stubs(:pluginconf).returns("choria.puppetdb_host" => nil, "choria.puppetdb_port" => "8081")
           choria.expects(:try_srv).with(["_x-puppet-db._tcp"], nil, nil).returns(:target => nil, :port => nil)
           choria.expects(:try_srv).with(["_x-puppet._tcp"], "puppet", "8081").returns(:target => "puppet", :port => "8084")
 


### PR DESCRIPTION
The MCollective::Util::Choria class does not process the choria settings
the same way choria does.  Ajust the code so that both implementations
behave in a similar way:

1. If a host is configured, use it;
2. Only do SRV lookups if SRV is enabled;
3. Fallback to `puppet` on port 8081.

While here fix the key used to check is SRV lookup should be done:
choria use `choria.use_srv`, not `choria.use_srv_records`.