### PR TITLE
(#151) Set the environment variable PT__task

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -186,6 +186,7 @@ module MCollective
           environment["PT_%s" % k] = v.to_s
         end
 
+        environment["PT__task"] = task["task"]
         environment["PT__installdir"] = File.join(request_spooldir(task_id), "files")
 
         environment

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -392,6 +392,7 @@ terminate called after throwing an instance of 'leatherman::json_container::data
             task_run_request_fixture["input_method"] = method
             task_run_request_fixture["input"] = '{"directory": "/tmp", "bool":true}'
             expect(ts.task_environment(task_run_request_fixture, "test_id", "caller=spec.mcollective")).to eq(
+              "PT__task" => "choria::ls",
               "PT__installdir" => File.join(cache, "test_1", "files"),
               "PT_directory" => "/tmp",
               "PT_bool" => "true",


### PR DESCRIPTION
When running a task, Bolt sets the name of that task in the `PR__task`
environment variable.  Commands run by Bolt can use this variable to
determine if running in the context of a Bolt task or not.

Also set this variable when running through choria so that code that
wants to behave differently when running from a Bolt task can go through
the same path when executed by the choria tasks support without needing
modification.

Fixes #151 