### PR TITLE
(#153) avoid exceeding the stack when logging setup fails

### DIFF
--- a/lib/mcollective/log.rb
+++ b/lib/mcollective/log.rb
@@ -96,9 +96,8 @@ module MCollective
         end
 
         @logger.start
-      rescue Exception => e # rubocop:disable Lint/RescueException
+      rescue Exception # rubocop:disable Lint/RescueException
         @configured = false
-        warn "Could not start logger: #{e.class} #{e}"
       end
 
       # figures out the filename that called us


### PR DESCRIPTION
Signed-off-by: R.I.Pienaar <rip@devco.net>