### PR TITLE
(#160) Move the stdout.read before the process

### DIFF
--- a/lib/mcollective/discovery/delegate.rb
+++ b/lib/mcollective/discovery/delegate.rb
@@ -53,6 +53,7 @@ module MCollective
 
           begin
             Timeout.timeout(timeout + 0.5) do
+              nodes.concat(JSON.parse(stdout.read))
               status = wait_thr.value
 
               raise("Choria discovery failed: %s" % stderr.read) unless status.exitstatus == 0
@@ -63,7 +64,6 @@ module MCollective
             raise("Choria failed to complete discovery within %d timeout" % timeout)
           end
 
-          nodes.concat(JSON.parse(stdout.read))
         end
 
         nodes

--- a/lib/mcollective/discovery/delegate.rb
+++ b/lib/mcollective/discovery/delegate.rb
@@ -63,7 +63,6 @@ module MCollective
             Process.kill("KILL", wait_thr[:pid])
             raise("Choria failed to complete discovery within %d timeout" % timeout)
           end
-
         end
 
         nodes


### PR DESCRIPTION
Pipe buffers aren't big enough to store all the data in the mean time, move the read to happen before the process.