### PR TITLE
(#98) Fix running bolt tasks on Windows

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -250,7 +250,7 @@ module MCollective
       # act on these tasks either by asking for their status or perhaps killing
       # them?
       #
-      # @param command [Array<String>] command to run
+      # @param command [String] command to run
       # @param environment [Hash] environment to run with
       # @param stdin [String] stdin to send to the command
       # @param spooldir [String] path to the spool for this specific request
@@ -291,7 +291,7 @@ module MCollective
             Process.exec(environment, command, options)
           end
         else
-          pid = Process.spawn(environment, command, options)
+          pid = Process.spawn(environment, [command, command], options)
         end
 
         sleep 0.1 until File.exist?(wrapper_stdout)

--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -65,7 +65,7 @@ module MCollective
       # AIO path to binaries like wrappers etc
       def aio_bin_path
         if Util.windows?
-          'C:\Program Files\Puppet Labs\Puppet\bin'
+          'C:\Program Files\Puppet Labs\Puppet\puppet\bin'
         else
           "/opt/puppetlabs/puppet/bin"
         end

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -509,7 +509,7 @@ terminate called after throwing an instance of 'leatherman::json_container::data
       describe "#bin_path" do
         it "should support windows" do
           Util.stubs(:windows?).returns(true)
-          expect(ts.aio_bin_path).to eq('C:\Program Files\Puppet Labs\Puppet\bin')
+          expect(ts.aio_bin_path).to eq('C:\Program Files\Puppet Labs\Puppet\puppet\bin')
         end
 
         it "should support nix" do


### PR DESCRIPTION
I took some time to continue digging in running tasks on windows (again).

Running a Ruby task:

```sh-session
romain@optiplex-3050 ~ % mco tasks run choria::ping --message=w00t -I /desktop-bpi/ -v  
Retrieving task metadata for task choria::ping from the Puppet Server
Discovering hosts using the mc method for 2 second(s) .... 1
Attempting to download and run task choria::ping on 1 nodes

Downloading and verifying 1 file(s) from the Puppet Server to all nodes: ✓  1 / 1

Running task choria::ping and waiting up to 60 seconds for it to complete

desktop-bpi073d.lan
   {"message":"w00t","timestamp":"2021-06-22 13:12:17 -1000"}



Summary for task 5a5e46d98cb05f18ae0853f097a9b346

                       Task Name: choria::ping
                          Caller: choria=romain.mcollective
                       Completed: 1
                         Running: 0

                      Successful: 1
                          Failed: 0

                Average Run Time: 0.14s


romain@optiplex-3050 ~ %
```

Running a PowerShell task (from the `puppetlas-exec` module):

```sh-session
romain@optiplex-3050 ~ % mco tasks run exec --command='echo w00t' -I /desktop-bpi/ -v                      
Retrieving task metadata for task exec from the Puppet Server
Discovering hosts using the mc method for 2 second(s) .... 1
Attempting to download and run task exec on 1 nodes

Downloading and verifying 3 file(s) from the Puppet Server to all nodes: ✓  1 / 1

Running task exec and waiting up to 60 seconds for it to complete

desktop-bpi073d.lan
   {"_output":"w00t\n","exit_code":0}



Summary for task 54690ef6afc451579159c94eb48f2013

                       Task Name: exec
                          Caller: choria=romain.mcollective
                       Completed: 1
                         Running: 0

                      Successful: 1
                          Failed: 0

                Average Run Time: 0.16s


romain@optiplex-3050 ~ %
```

Fixes #98

:man_dancing: 