### PR TITLE
(#163) Add AIO binary to the PATH

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -176,9 +176,10 @@ module MCollective
         environment = {
           "_task" => task["task"],
           "_choria_task_id" => task_id,
-          "_choria_task_caller" => task_caller,
-          "PATH" => "#{aio_bin_path}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
+          "_choria_task_caller" => task_caller
         }
+
+        environment["PATH"] = "#{aio_bin_path}#{File::PATH_SEPARATOR}#{ENV['PATH']}" if File.directory?(aio_bin_path)
 
         return environment unless task["input"]
         return environment unless ["both", "environment"].include?(task_input_method(task))

--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -176,7 +176,8 @@ module MCollective
         environment = {
           "_task" => task["task"],
           "_choria_task_id" => task_id,
-          "_choria_task_caller" => task_caller
+          "_choria_task_caller" => task_caller,
+          "PATH" => "#{aio_bin_path}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
         }
 
         return environment unless task["input"]

--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -88,6 +88,13 @@ module MCollective
         end
       end
 
+      # Is this an AIO install?
+      #
+      # @return [Boolean]
+      def aio?
+        File.directory?(aio_bin_path)
+      end
+
       # Path to the task wrapper executable
       #
       # @return [String]
@@ -179,7 +186,7 @@ module MCollective
           "_choria_task_caller" => task_caller
         }
 
-        environment["PATH"] = "#{aio_bin_path}#{File::PATH_SEPARATOR}#{ENV['PATH']}" if File.directory?(aio_bin_path)
+        environment["PATH"] = "#{aio_bin_path}#{File::PATH_SEPARATOR}#{ENV['PATH']}" if aio?
 
         return environment unless task["input"]
         return environment unless ["both", "environment"].include?(task_input_method(task))

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -262,6 +262,7 @@ terminate called after throwing an instance of 'leatherman::json_container::data
           File.stubs(:exist?).with(ts.wrapper_path).returns(true)
           ts.stubs(:request_spooldir).returns(File.join(cache, "test_1"))
           ts.stubs(:populate_spooldir)
+          ts.stubs(:aio?).returns(true)
 
           ts.expects(:spawn_command).with(
             "/opt/puppetlabs/puppet/bin/task_wrapper",
@@ -391,6 +392,7 @@ terminate called after throwing an instance of 'leatherman::json_container::data
         it "should set the environment for both or environment methods" do
           ["both", "environment"].each do |method|
             ts.stubs(:request_spooldir).returns(File.join(cache, "test_1"))
+            ts.stubs(:aio?).returns(true)
             task_run_request_fixture["input_method"] = method
             task_run_request_fixture["input"] = '{"directory": "/tmp", "bool":true}'
             expect(ts.task_environment(task_run_request_fixture, "test_id", "caller=spec.mcollective")).to eq(
@@ -408,6 +410,7 @@ terminate called after throwing an instance of 'leatherman::json_container::data
 
         it "should not set it otherwise" do
           ["powershell", "stdin"].each do |method|
+            ts.stubs(:aio?).returns(true)
             task_run_request_fixture["input_method"] = method
             expect(ts.task_environment(task_run_request_fixture, "test_id", "caller=spec.mcollective")).to eq(
               "_task" => "choria::ls",

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -13,6 +13,7 @@ module MCollective
       let(:task_fixture_rb) { File.read("spec/fixtures/tasks/choria_ls.rb") }
       let(:file) { task_fixture["files"].first }
       let(:task_run_request_fixture) { JSON.parse(File.read("spec/fixtures/tasks/task_run_request.json")) }
+      let(:path_with_aio_bin_prepended) { "/opt/puppetlabs/puppet/bin:#{ENV['PATH']}" }
 
       before(:each) do
         choria.stubs(:puppet_server).returns(:target => "stubpuppet", :port => 8140)
@@ -267,7 +268,8 @@ terminate called after throwing an instance of 'leatherman::json_container::data
             {
               "_task" => "choria::ls",
               "_choria_task_id" => "test_1",
-              "_choria_task_caller" => "choria=local.mcollective"
+              "_choria_task_caller" => "choria=local.mcollective",
+              "PATH" => path_with_aio_bin_prepended
             },
             instance_of(String),
             File.join(cache, "test_1"),
@@ -398,7 +400,8 @@ terminate called after throwing an instance of 'leatherman::json_container::data
               "PT_bool" => "true",
               "_task" => "choria::ls",
               "_choria_task_caller" => "caller=spec.mcollective",
-              "_choria_task_id" => "test_id"
+              "_choria_task_id" => "test_id",
+              "PATH" => path_with_aio_bin_prepended
             )
           end
         end
@@ -409,7 +412,8 @@ terminate called after throwing an instance of 'leatherman::json_container::data
             expect(ts.task_environment(task_run_request_fixture, "test_id", "caller=spec.mcollective")).to eq(
               "_task" => "choria::ls",
               "_choria_task_caller" => "caller=spec.mcollective",
-              "_choria_task_id" => "test_id"
+              "_choria_task_id" => "test_id",
+              "PATH" => path_with_aio_bin_prepended
             )
           end
         end


### PR DESCRIPTION
This match the Bolt behavior of using Puppet's version of Ruby to run
tasks, and helps with tasks which rely on Puppet components such as
facter.

Fixes #163