### PR TITLE
(#173) handle Integer as valid Float in validation

### DIFF
--- a/lib/mcollective/validator/typecheck_validator.rb
+++ b/lib/mcollective/validator/typecheck_validator.rb
@@ -12,7 +12,7 @@ module MCollective
         when :integer
           validator.is_a?(Integer)
         when :float
-          validator.is_a?(Float)
+          validator.is_a?(Float) || validator.is_a?(Integer)
         when :number
           validator.is_a?(Numeric)
         when :string

--- a/spec/unit/mcollective/ddl/base_spec.rb
+++ b/spec/unit/mcollective/ddl/base_spec.rb
@@ -157,10 +157,7 @@ module MCollective
             @ddl.validate_input_argument(@ddl.entities[:test][:input], :float, "1")
           }.to raise_error("Cannot validate input float: value should be a float")
 
-          expect {
-            @ddl.validate_input_argument(@ddl.entities[:test][:input], :float, 1)
-          }.to raise_error("Cannot validate input float: value should be a float")
-
+          @ddl.validate_input_argument(@ddl.entities[:test][:input], :float, 1)
           @ddl.validate_input_argument(@ddl.entities[:test][:input], :float, 1.1)
         end
 

--- a/spec/unit/mcollective/validator/typecheck_validator_spec.rb
+++ b/spec/unit/mcollective/validator/typecheck_validator_spec.rb
@@ -18,6 +18,10 @@ module MCollective
           TypecheckValidator.validate(*val)
         end
       end
+
+      it "should treat ints as floats for float type" do
+        TypecheckValidator.validate(200, :float)
+      end
     end
   end
 end


### PR DESCRIPTION
Ruby JSON parser will parse 200 as an int, and can
safely be used where floats are supposed to be thanks
to dynamic types

So we should hnadle that so f=200 on the CLI works,
go code does the equivelant already

Signed-off-by: R.I.Pienaar <rip@devco.net>