### PR TITLE
Update tasks_support.rb

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -167,8 +167,8 @@ module MCollective
         file_name = File.join(spooldir, "files", task_module(task["task"]), "tasks", file_spec["filename"])
 
         command = platform_specific_command(file_name)
-
-        command.unshift(ps_shim_path) if task_input_method(task) == "powershell"
+        # the ps_shim_path should be before the actual powershell task script instead of the front. 
+        command.insert(-2, ps_shim_path) if task_input_method(task) == "powershell"
 
         command
       end


### PR DESCRIPTION
When I test choria using powershell task in windows, the powershell script wasn't triggered properly. After investigation, the execuator wrapper.exe can only work when you put the ps_shim_path after the powershell command: 
the correct way is: 
"powershell", "-NoProfile", "-NonInteractive", "-NoLogo", "-ExecutionPolicy", "Bypass", "-File", "<path to>PowershellShim.ps1" <taskscript>.ps1 
**not**
"<path to>PowershellShim.ps1" "powershell", "-NoProfile", "-NonInteractive", "-NoLogo", "-ExecutionPolicy", "Bypass", "-File", <taskscript>.ps1