### PR TITLE
Drop removed safe_level kwarg to erb.new

### DIFF
--- a/lib/mcollective/pluginpackager/forge_packager.rb
+++ b/lib/mcollective/pluginpackager/forge_packager.rb
@@ -191,7 +191,7 @@ module MCollective
       end
 
       def render_template(infile, outfile)
-        erb = ERB.new(File.read(infile), :safe_level => 0, :trim_mode => "-")
+        erb = ERB.new(File.read(infile), :trim_mode => "-")
         File.open(outfile, "w") do |f|
           f.puts erb.result(binding)
         end


### PR DESCRIPTION
Was deprecated many years ago: https://bugs.ruby-lang.org/issues/14256 Can't find any references to actual removal, but it's no longer available under puppet 8/ruby 3.2, and `mco plugin package` crashes without this change.