### PR TITLE
(#209) Redact inputs in spool files

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -392,6 +392,17 @@ module MCollective
 
         wait_for_task_completion(requestid) if wait
 
+        # Redact inputs from choria.json
+        redacted_data = JSON.load File.open(File.join(spool, "choria.json"))
+        redacted_data["request"]["input"] = {}
+
+        File.open(File.join(spool, "choria.json"), "w") do |meta|
+          meta.print(redacted_data.to_json)
+        end
+
+        # Delete wrapper_stdin
+        File.delete(File.join(spool, "wrapper_stdin"))
+
         task_status(requestid)
       end
 


### PR DESCRIPTION
Associated issue: https://github.com/choria-io/mcorpc-ruby-support/issues/209

- Redact `metadata['request']['input']` from `choria.json`
- Remove `wrapper_stdin`

Sample after applying changes:

```
/opt/puppetlabs/mcollective/tasks-spool # cat 9818ae3c4cc5507fb4abf20927f88adb/choria.json | jq
{
  "start_time": 1752186657,
  "caller": "choria=me.mcollective",
  "task": "my_tasks::sleep_with_pwd_ruby",
  "request": {
    "executable": "/opt/puppetlabs/mcollective/tasks-spool/9818ae3c4cc5507fb4abf20927f88adb/files/my_tasks/tasks/sleep_with_pwd_ruby.rb",
    "arguments": [],
    "input": {},
    "stdout": "/opt/puppetlabs/mcollective/tasks-spool/9818ae3c4cc5507fb4abf20927f88adb/stdout",
    "stderr": "/opt/puppetlabs/mcollective/tasks-spool/9818ae3c4cc5507fb4abf20927f88adb/stderr",
    "exitcode": "/opt/puppetlabs/mcollective/tasks-spool/9818ae3c4cc5507fb4abf20927f88adb/exitcode"
  }
}
/opt/puppetlabs/mcollective/tasks-spool # cat 9818ae3c4cc5507fb4abf20927f88adb/wrapper_stdin
cat: wrapper_stdin: No such file or directory
```

I can still retrieve the task summary and metadata:

```
~$ mco tasks status 9818ae3c4cc5507fb4abf20927f88adb -v -I server123 --summary

 * [ ============================================================> ] 1 / 1



Summary for task 9818ae3c4cc5507fb4abf20927f88adb

                       Task Name: my_tasks::sleep_with_pwd_ruby
                          Caller: choria=me.mcollective
                       Completed: 1
                         Running: 0

                      Successful: 1
                          Failed: 0

                Average Run Time: 5.09s
```

And metadata:

```
~$ mco tasks status 9818ae3c4cc5507fb4abf20927f88adb -v -I server123 --metadata

 * [ ============================================================> ] 1 / 1

  server123


---- Task Stats ----
           Nodes: 1 / 1
     Pass / Fail: 0 / 1
      Start Time: 2025-07-11 19:58:35 +0000
  Discovery Time: 0.00ms
      Agent Time: 1059.72ms
      Total Time: 1059.72ms
```